### PR TITLE
Creación del script simulate_drift.sh y del esqueleto del balanceador.py y su estructura de carpetas

### DIFF
--- a/balanceador/balanceador.py
+++ b/balanceador/balanceador.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+BALANCEADOR ESQUELETO
+Aquí prepararemos la base para:
+    - leer carpetas incoming_requests/
+    - distribuir archivos round-robin entre service_1, service_2, service_3
+    - más adelante: health-checks y logs JSON
+"""
+
+import time
+
+def main():
+    
+    # Aquí irán las llamadas a las funciones de distribute() y health_check()
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_drift.sh
+++ b/scripts/simulate_drift.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# timestamp para distinguir cada ejecución
+timestamp=$(date +%Y-%m-%d_%H-%M-%S)
+
+# modificar un valor en iac/main.tf para forzar drift
+sed -i "s/always_run = .*/always_run = \"$timestamp\"/" ../iac/main.tf
+
+# ejecutar terraform plan y guardar log
+mkdir -p ../logs
+
+# 4. Entrar en la carpeta iac, correr plan, muestrar y guardar la salida en ../logs
+cd ../iac
+
+terraform init -input=false        # ← inicializa sin pedir interacción
+terraform plan | tee ../logs/drift_"$timestamp".log
+
+cd ..
+echo "Drift simulado: log en logs/drift_$timestamp.log"


### PR DESCRIPTION
## Cambios realizados
- **Se creó el scripts/simulate_drift.sh**  
  - Genera un timestamp y lo inyecta en `iac/main.tf` para forzar un drift  
  - Ejecuta `terraform init -input=false` y `terraform plan`, guardando el output en `logs/drift_<timestamp>.log`
- **Se creó el balanceador/balanceador.py** (esqueleto)  
  - Define `main()` vacío con comentarios para `distribute()` y `health_check()`  
  - Estructura de carpetas vacías:
    - `balanceador/incoming_requests/`
    - `balanceador/service_1/`, `balanceador/service_2/`, `balanceador/service_3/`
 