### PR TITLE
Refactorización de scripts del sprint 1 y cambio en la estructura

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# Proyecto 7 - Operaciones con Terraform
+# Proyecto 7 - Operaciones y recuperación ante desastres locales para infraestructura Terraform
+
+**Integrantes**
+- Daren Adiel Herrera Romo (scptx0)
+- Renzo Quispe Villena (RenzoQuispe)
+- Andre Sanchez Vega (AndreSanchezVega)
+
+## Descripción
+
+Solución local para manejar el ciclo de vida completo de una infraestructura dummy de Terraform:
+- Backup/restauración de estado
+- Alta disponibilidad
+- Balanceador de carga local en Python
+- Simulación de drift
+- Gestión de costos simulados mediante scripts bash
+
+## Estructura del proyecto
+
+```
+├── iac/                   # Infraestructura
+│   └── main.tf            # Recursos dummy (null_resource)
+├── scripts/
+│   ├── backup_state.sh    # Script de backup de tfstate con timestamp
+│   └── restore_state.sh   # Script para restauración interactiva
+├── balanceador/
+│   ├── balanceador.py     # Balanceador (Python)
+│   ├── incoming_requests/ # Carpeta para solicitudes
+│   ├── service_1/         # Instancia dummy 1
+│   ├── service_2/         # Instancia dummy 2
+│   └── service_3/         # Instancia dummy 3
+└── logs/                  # Registros de operaciones
+```
+
+## Requisitos técnicos
+
+## ¿Cómo usar el proyecto?
+
+## Diagrama ASCII del flujo de balanceo y backup/restauración.

--- a/balanceador/balanceador.py
+++ b/balanceador/balanceador.py
@@ -8,8 +8,8 @@ Aquí prepararemos la base para:
 
 import time
 
+
 def main():
-    
     # Aquí irán las llamadas a las funciones de distribute() y health_check()
     pass
 

--- a/balanceador/balanceador.py
+++ b/balanceador/balanceador.py
@@ -1,0 +1,18 @@
+"""
+BALANCEADOR ESQUELETO
+Aquí prepararemos la base para:
+    - leer carpetas incoming_requests/
+    - distribuir archivos round-robin entre service_1, service_2, service_3
+    - más adelante: health-checks y logs JSON
+"""
+
+import time
+
+def main():
+    
+    # Aquí irán las llamadas a las funciones de distribute() y health_check()
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,0 +1,18 @@
+# Recursos dummy que crean archivos .txt en el directorio actual.
+resource "null_resource" "service_1" {
+    provisioner "local-exec" {
+        command = "echo 'Ejemplo de servicio 1' > service_1.txt"
+    }
+}
+
+resource "null_resource" "service_2" {
+    provisioner "local-exec" {
+        command = "echo 'Ejemplo de servicio 2' > service_2.txt"
+    }
+}
+
+resource "null_resource" "service_3" {
+    provisioner "local-exec" {
+        command = "echo 'Ejemplo de servicio 3' > service_3.txt"
+    }
+}

--- a/scripts/backup_state.sh
+++ b/scripts/backup_state.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# se crea la carpeta backups si no existe
+ruta_a_este_script="$(realpath "$0")"
+ruta_carpeta_scripts="$(dirname "$ruta_a_este_script")"
+ruta_raiz_proyecto="$(dirname "$ruta_carpeta_scripts")"
+mkdir -p "$ruta_raiz_proyecto/backups"
+# creacion de una copia de terraform.tfstate a backups, se coloca timestamp para diferenciar entre backups
+timestamp="$(date +"%Y-%m-%d_%H-%M-%S")"
+ruta_terraform_state="$ruta_raiz_proyecto/iac/terraform.tfstate"
+ruta_nuevo_backup="$ruta_raiz_proyecto/backups/tfstate_${timestamp}.backup"
+cp "$ruta_terraform_state" "$ruta_nuevo_backup"

--- a/scripts/restore_state.sh
+++ b/scripts/restore_state.sh
@@ -12,7 +12,7 @@ if [ ! -d "$ruta_carpeta_backups" ]; then
   exit 1
 fi
 # lista de los archivos_backups que hay en la carpeta backups
-archivos_backups=($(ls "$ruta_carpeta_backups"))
+read -ra archivos_backups <<< "$(ls "$ruta_carpeta_backups")"
 numero_backups=${#archivos_backups[@]}
 # verificar si hay archivos backup
 if [ "$numero_backups" -eq 0 ]; then

--- a/scripts/restore_state.sh
+++ b/scripts/restore_state.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Este script muestra la lista de los archivos backup y permita elegir uno mediante un menu y lo copia en iac/terraform.tfstate
+# rutas necesarias para el script
+ruta_a_este_script=$(realpath "$0")
+ruta_carpeta_scripts=$(dirname "$ruta_a_este_script")
+ruta_raiz_proyecto=$(dirname "$ruta_carpeta_scripts")
+ruta_carpeta_backups="$ruta_raiz_proyecto/backups"
+ruta_terraform_state="$ruta_raiz_proyecto/iac/terraform.tfstate"
+# verificar que la carpeta de backups existe
+if [ ! -d "$ruta_carpeta_backups" ]; then
+  echo "la carpeta de backups no existe"
+  exit 1
+fi
+# lista de los archivos_backups que hay en la carpeta backups
+archivos_backups=($(ls "$ruta_carpeta_backups"))
+numero_backups=${#archivos_backups[@]}
+# verificar si hay archivos backup
+if [ "$numero_backups" -eq 0 ]; then
+  echo "No se encontraron archivos backups"
+  exit 1
+fi
+# menu de backups para escoger
+echo "Lista de backups"
+for i in "${!archivos_backups[@]}"; do
+  numero=$((i+1))
+  echo "$numero- ${archivos_backups[$i]}"
+done
+# leer la opcion escogida
+while true; do
+  read -p "Escribe la opcion del backup que quieres restaurar: " opcion
+  # verificar que el valor ingresado sea valido
+  if [[ "$opcion" =~ ^[0-9]+$ ]]; then  # uso de expresion regular para validar que la entrada se un numero entero positivo
+    if [ "$opcion" -ge 1 ]; then
+      if [ "$opcion" -le "$numero_backups" ]; then
+        break
+      else
+        echo "no existe esa opcion"
+      fi
+    else
+      echo "no existe esa opcion"
+    fi
+  else
+    echo "no existe esa opcion, ingresar un numero valido"
+  fi
+done
+# copiar el backup escogido a iac/terraform.tfstate
+backup_escogido="${archivos_backups[$((opcion-1))]}"
+ruta_backup_escogido="$ruta_carpeta_backups/$backup_escogido"
+cp "$ruta_backup_escogido" "$ruta_terraform_state"
+echo "backup realizado"
+

--- a/scripts/simulate_drift.sh
+++ b/scripts/simulate_drift.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# timestamp para distinguir cada ejecución
+timestamp=$(date +%Y-%m-%d_%H-%M-%S)
+
+#Para forzar el drfit cambiamos el nombre del recurso "service_1" a "service_1_drift"
+# en ../iac/main.tf para que terraform plan detecte una desviación
+sed -i 's/resource "null_resource" "service_1"/resource "null_resource" "service_1_drift"/' ../iac/main.tf
+
+# ejecutamos terraform plan y guardamos en log
+mkdir -p ../logs
+
+cd ../iac
+
+#corremos plan, luego mostrar y guardar la salida en ../logs
+terraform init -input=false        # ← inicializa sin pedir interacción
+terraform plan | tee ../logs/drift_"$timestamp".log
+
+cd ..
+echo "Drift simulado: log en logs/drift_$timestamp.log"

--- a/scripts/simulate_drift.sh
+++ b/scripts/simulate_drift.sh
@@ -10,11 +10,10 @@ sed -i 's/resource "null_resource" "service_1"/resource "null_resource" "service
 # ejecutamos terraform plan y guardamos en log
 mkdir -p ../logs
 
-cd ../iac
+cd ../iac || exit 1 # En el caso de que el cd falle.
 
 #corremos plan, luego mostrar y guardar la salida en ../logs
 terraform init -input=false        # ← inicializa sin pedir interacción
 terraform plan | tee ../logs/drift_"$timestamp".log
 
-cd ..
 echo "Drift simulado: log en logs/drift_$timestamp.log"


### PR DESCRIPTION
## Cambios realizados
- Se eliminó el duplicado erróneo de `balanceador.py` en `src/`.
- Se formateó, de acuerdo con PEP8, `balanceador.py` y se usó `shellcheck` para la validación de formato de los scripts `simulate_drift.sh` y `restore_state.sh`.

## Issues relacionados
- #1 
- #14 