### PR TITLE
Creación de script cost_saving.sh e integración del mismo en balanceador.py

### DIFF
--- a/balanceador/balanceador.py
+++ b/balanceador/balanceador.py
@@ -2,6 +2,7 @@ import time
 import os
 import json
 import threading
+import subprocess
 
 # Ruta en la que se encuentra este script
 DIR_BASE = os.path.dirname(os.path.abspath(__file__))
@@ -9,6 +10,7 @@ DIR_REQUESTS = os.path.join(DIR_BASE, "incoming_requests")
 DIR_ERRORS = os.path.join(DIR_BASE, "errors")
 DIR_LOGS = os.path.join(DIR_BASE, "logs")
 DIR_SETTINGS = os.path.join(DIR_BASE, "settings.json")
+SCRIPT_COST = os.path.join(DIR_BASE, "..", "scripts", "cost_saving.sh")
 
 NUM_SERVICIOS = 0
 SERVICIOS_ACTIVOS = 0
@@ -209,6 +211,10 @@ def loop_balanceo():
     delay = get_delay()          # valor inicial
     while True:
         inicializar_servicios()
+        # ejecución del cost-saving 
+        subprocess.run(["bash", SCRIPT_COST], check=True)
+
+        #inicializar y procesar
         procesar_archivos()
         time.sleep(delay)        # espera el retardo actual
         delay = get_delay(delay)  # relee settings.json por si cambió

--- a/scripts/cost_saving.sh
+++ b/scripts/cost_saving.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# scripts/cost_saving.sh — apaga/enciende service_3 según hora del día
+
+#Calcula rutas base
+BASE="$(cd "$(dirname "$0")" && pwd)"          # …/Proyecto-7/scripts
+BAL_DIR="$BASE/../balanceador"                # …/Proyecto-7/balanceador
+SERVICE="$BAL_DIR/service_3"                  # carpeta servicio 3
+ARCHIVE_ROOT="$BASE/../archived"              # …/Proyecto-7/archived
+ARCHIVE="$ARCHIVE_ROOT/service_3"             # …/Proyecto-7/archived/service_3
+LOG="$BAL_DIR/logs/cost.log"                  # archivo de historial de costos
+
+#Asegura carpetas de archive y logs
+mkdir -p "$ARCHIVE_ROOT"
+mkdir -p "$(dirname "$LOG")"
+
+#Lee hora y minuto en 24h
+HOUR=$(date +%H)
+MIN=$(date +%M)
+
+#Decide acción según horario
+#    - apagar entre 00:00 y 06:00 (inclusive)
+#    - encender entre 06:01 y 23:59
+if [ "$HOUR" -lt 6 ] || { [ "$HOUR" -eq 6 ] && [ "$MIN" -eq 0 ]; }; then
+    # Apagar: mueve service_3/ a archived/
+    if [ -d "$SERVICE" ]; then
+        mv "$SERVICE" "$ARCHIVE"
+        echo "$(date '+%Y-%m-%d %H:%M:%S')  Apagado service_3" >> "$LOG"
+    fi
+else
+    # Encender: restaura si está archivado
+    if [ ! -d "$SERVICE" ] && [ -d "$ARCHIVE" ]; then
+        mv "$ARCHIVE" "$SERVICE"
+        echo "$(date '+%Y-%m-%d %H:%M:%S')  Encendido service_3" >> "$LOG"
+    fi
+fi


### PR DESCRIPTION
### Cambios realizados (Sprint 3)

* **`scripts/cost_saving.sh`**  
  * Nuevo script Bash que, según la hora del sistema (24 h), apaga/enciende `service_3/`:  

* **Integración en `balanceador/balanceador.py`**  
 
  * En cada iteración de `loop_balanceo()`, antes de procesar peticiones, ejecuta `cost_saving.sh` 

---

### Cómo probar

```bash
# 1. Generar peticiones de prueba
bash scripts/simulate_requests.sh

# 2. Arrancar el balanceador (daemon en background)
nohup python3 balanceador/balanceador.py > balanceador/logs/daemon.log 2>&1 &

